### PR TITLE
Use napi canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
   "dependencies": {
-    "canvas": "^2.6.1",
+    "@napi-rs/canvas": "^0.1.70",
     "commander": "^4.1.0",
     "opentype.js": "1.3.4",
     "pngquant": "^4.2.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { generateBitmap } from "./generateBitmap";
 import { parseArgs } from "node:util";
 import * as path from "path";
 import * as fs from "fs";
-import * as canvas from "canvas";
+import * as canvas from "@napi-rs/canvas";
 import {outputBitmapFont} from "./outputBitmapFont";
 
 export function run (argv: string[]): void {

--- a/src/generateBitmap.ts
+++ b/src/generateBitmap.ts
@@ -73,7 +73,6 @@ function draw(ctx: canvas.SKRSContext2D, glyphList: Glyph[], resolvedSizeOption:
         }
         drawX += width + resolvedSizeOption.margin;
     });
-
     // NOTE: missingGlyphが末尾でない仕様が許されるか？
     return {map: dict, missingGlyph};
 }

--- a/src/generateBitmap.ts
+++ b/src/generateBitmap.ts
@@ -1,4 +1,4 @@
-import * as canvas from "canvas";
+import * as canvas from "@napi-rs/canvas";
 import { FontRenderingOptions, SizeOptions, ResolvedSizeOption, Glyph, ImageGlyph, BitmapDictionaryEelement, BitmapDictionary } from "./type";
 import { calculateCanvasSize, calculateResolvedSizeOption, calculateWidthAverage, charsToGlyphList, updateGlyphListWithImage } from "./util";
 
@@ -25,9 +25,7 @@ export function generateBitmap(
 
     const canvasSize = calculateCanvasSize(glyphList, resolvedSizeOption.width, resolvedSizeOption.lineHeight, resolvedSizeOption.margin);
     const cvs = canvas.createCanvas(canvasSize.width, canvasSize.height);
-	const ctx = cvs.getContext("2d");
-    if (fontOptions.antialias) ctx.antialias = "none";
-
+    const ctx = cvs.getContext("2d");
     const drawResult = draw(ctx, glyphList, resolvedSizeOption, fontOptions);
 
 	return Promise.resolve({
@@ -38,7 +36,7 @@ export function generateBitmap(
 	});
 }
 
-function draw(ctx: canvas.CanvasRenderingContext2D, glyphList: Glyph[], resolvedSizeOption: ResolvedSizeOption, fontOptions: FontRenderingOptions): {
+function draw(ctx: canvas.SKRSContext2D, glyphList: Glyph[], resolvedSizeOption: ResolvedSizeOption, fontOptions: FontRenderingOptions): {
     map: BitmapDictionary,
     missingGlyph: BitmapDictionaryEelement
 } {
@@ -75,6 +73,7 @@ function draw(ctx: canvas.CanvasRenderingContext2D, glyphList: Glyph[], resolved
         }
         drawX += width + resolvedSizeOption.margin;
     });
+
     // NOTE: missingGlyphが末尾でない仕様が許されるか？
     return {map: dict, missingGlyph};
 }

--- a/src/outputBitmapFont.ts
+++ b/src/outputBitmapFont.ts
@@ -1,16 +1,18 @@
 import PngQuant from "pngquant";
-import * as canvas from "canvas";
+import * as canvas from "@napi-rs/canvas";
 import * as fs from "fs";
 
 export  function outputBitmapFont(output: string, cvs: canvas.Canvas, quality?: number) {
     return new Promise<void>((resolve, reject) => {
         if (quality) return compressPNG(output, cvs, quality);
 
-        cvs.toBuffer((error: any, result: Buffer) => {
-            if (error) reject(error);
-            fs.writeFileSync(output, result);
+        try {
+            const buffer = cvs.toBuffer("image/png");
+            fs.writeFileSync(output, buffer);
             resolve();
-        });
+        } catch (error: any) {
+            reject(error);
+        }
     });
 }
 
@@ -27,6 +29,6 @@ function compressPNG(output: string, cvs: canvas.Canvas, quality: number): Promi
                 resolve();
             })
             .on("error", () => reject("error at pngquant"));
-        cvs.createPNGStream().pipe(pngQuanter);
+        cvs.encodeStream("png").pipeTo(pngQuanter);
     });
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,4 @@
-import type { Image } from "canvas";
+import * as canvas from "@napi-rs/canvas";
 
 export interface BmpfontGeneratorCliConfig {
 	source: string;
@@ -6,7 +6,7 @@ export interface BmpfontGeneratorCliConfig {
 	fixedWidth?: number;
 	height: number;
 	chars: string;
-	missingGlyph?: string | Image;
+	missingGlyph?: string | canvas.Image;
 	missingGlyphImage?: string;
 	fill: string;
 	stroke?: string;
@@ -85,7 +85,7 @@ export interface CharGlyph {
 
 export interface ImageGlyph {
     width: number;
-    image: Image;
+    image: canvas.Image;
 }
 
 export interface BitmapDictionary {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import * as canvas from "canvas";
+import * as canvas from "@napi-rs/canvas";
 import * as opentype from "opentype.js";
 import type { SizeOptions, Glyph, ResolvedSizeOption, CharGlyph, ImageGlyph } from "./type";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "strict": true
   },
   "files": [
-    "./node_modules/canvas/types/index.d.ts",
     "./src/cli.ts"
   ]
 }


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
bmpfont-generatorのcanvas実装をnode-canvasから@napi-rs/canvasに置き換えます。
これにより、動作環境にcairoをインストールする必要がなくなります。

## 破壊的な変更を含んでいるか?

- あり

`--no-anti-alias` オプションが動作しなくなります。このサポート対応は別PRにて行います。

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

