### PR TITLE
update workflows for security

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -12,8 +15,10 @@ jobs:
         node: [18.x, 20.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm


### PR DESCRIPTION
### やったこと
- GithubActionsワークフローのセキュリティ対応
  - 各モジュール使用時にバージョンやタグではなく、SHA PINを指定
    - SHA PINの指定のために、pinactを利用
  - permissionsの指定
  - checkout アクションに`persist-credentials: false`追加