### PR TITLE
update release.yml for trusted publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,11 @@ on:
       - master
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 24
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -19,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -32,4 +33,4 @@ jobs:
         uses: akashic-games/action-release@e4e3c8901b8ed92356c5eb9cf6cfc573a9c4ce9b # v2.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          npm_token: ${{ secrets.NPM_TOKEN }}
+          npm_token: "dummy" # action-release の内部で利用しているライブラリが npm トークンを必須としているためダミーを設定


### PR DESCRIPTION
### やったこと
publish.yml で Trusted Publish に対応するために以下の変更を加えた。
- nodeのバージョンをv24に更新(npm 11.5.1以降でないとTrusted Publishに対応していないため)
- permissions: id-token: write を追加
- publish時に ダミーのNPMトークンを渡すように
  - action-release内部で使っているライブラリがNPMトークンを必須にしているため