### PR TITLE
Mod npm install --before option in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,23 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
+      - name: Make value for before option
+        id: date-value
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7.1.0
+        with:
+          script: |
+            const dt = new Date()
+            dt.setDate(dt.getDate() - 7)
+            const beforeDate = dt.toLocaleDateString("ja-JP", {year: "numeric", month: "2-digit", day: "2-digit"}).replaceAll('/', '-')
+            return beforeDate
+          result-encoding: string
       - name: Prepare
         run: |
-          npm ci
+          npm i --before ${{ steps.date-value.outputs.result }}
+          if [[ `git status --porcelain` ]]; then
+            echo "- npm install results in changes!"
+            exit 1
+          fi
           npm test
           npm shrinkwrap
       - name: Publish and Release


### PR DESCRIPTION
## 概要

release.yml で npm i --before <date> を実行するようにします。
npm i 後に差分が出る場合には、異常終了とします。

**備考**
動作確認等は https://github.com/akashic-games/complete-audio/pull/32 で行っています。